### PR TITLE
Papers references: use links to publicly available versions instead o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Compositional Data Types [![Build Status](https://travis-ci.org/pa-ba/compdata.svg?branch=master)](https://travis-ci.org/pa-ba/compdata)
 
 This library implements the ideas of
-[*Data types a la carte*](http://dx.doi.org/10.1017/S0956796808006758)
-(Journal of Functional Programming, 18(4):423-436, 2008) as outlined
-in the paper
-[*Compositional data types*](http://dx.doi.org/10.1145/2036918.2036930)
-(Workshop on Generic Programming, 83-94, 2011). The purpose of this
+[*Data types a la carte*](https://www.staff.science.uu.nl/%7Eswier004/Publications/DataTypesALaCarte.pdf)
+(Wouter Swiestra, Journal of Functional Programming, 18(4):423-436, 2008) as outlined in the paper
+[*Compositional data types*](http://www.diku.dk/~paba/pubs/entries/bahr11wgp.html)
+(Patrick Bahr and Tom Hvitved, Workshop on Generic Programming, 83-94, 2011). The purpose of this
 library is to allow the programmer to construct data types -- as well
 as the functions defined on them -- in a modular fashion. The
 underlying idea is to separate the signature of a data type from the


### PR DESCRIPTION
…f a DOI pointing to paywalled copies

The use of DOI links can prevent some potential readers of your paper to access them, because they follow the link and end up on paywalls without access to the paper (see [an example here](https://www.reddit.com/r/haskell/comments/3lj1vw/typelevel_sum_hell_and_how_to_avoid_it/cv6tmqw) of a user not reading the paper for this reason). This pull requests replaces the links with links to publicly available version of the cited articles, and also add the author names to help further search of them (making references just as unique as the DOI numbers), in case one of those URLs became unavailable at some point in the future.