### PR TITLE
Update code to work with GHC 8.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
  - CABALVER=1.18 GHCVER=7.8.4  HAPPYVER=1.19.5
  - CABALVER=1.22 GHCVER=7.10.3 HAPPYVER=1.19.5
  - CABALVER=1.24 GHCVER=8.0.1  HAPPYVER=1.19.5
+ - CABALVER=1.24 GHCVER=8.2.2  HAPPYVER=1.19.5
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/compdata.cabal
+++ b/compdata.cabal
@@ -187,7 +187,7 @@ library
                         Data.Comp.Multi.Derive.SmartConstructors
                         Data.Comp.Multi.Derive.SmartAConstructors
 
-  Build-Depends:	base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.9, derive,
+  Build-Depends:	base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.11.3, derive,
                         deepseq, th-expand-syns, transformers, tree-view >= 0.5
   Extensions:           FlexibleContexts
   hs-source-dirs:	src
@@ -198,7 +198,7 @@ Test-Suite test
   Type:                 exitcode-stdio-1.0
   Main-is:		Data_Test.hs
   hs-source-dirs:	testsuite/tests examples src
-  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.9, 
+  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.11.3,
                         HUnit, test-framework, test-framework-hunit, test-framework-quickcheck2 >= 0.3, derive,
                         th-expand-syns, deepseq, transformers
 
@@ -209,7 +209,7 @@ Benchmark algebra
   ghc-options:          -W -O2
   -- Disable short-cut fusion rules in order to compare optimised and unoptimised code.
   cpp-options:          -DNO_RULES
-  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.9, derive, deepseq, criterion, random, uniplate, th-expand-syns, transformers
+  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1, QuickCheck >= 2 && < 2.11.3, derive, deepseq, criterion, random, uniplate, th-expand-syns, transformers
 
 
 source-repository head


### PR DESCRIPTION
Hi, I updated the code to work around the template haskell change in GHC 8.2. Compile error described here: #24 

My change just ignores the new DerivStrategy value that is now exposed in template haskell 2.12.0.

I also relaxed the upper bound for QuickCheck to 2.11.3 (Maybe I should extract this into a separate PR?).

When I ran the tests, they compiled and succeeded. The benchmarks, unfortunately, did not compile successfully. I got the following error. Not really sure what to do about that.

```
<no location info>: error:
    ghc: panic! (the 'impossible' happened)
  (GHC version 8.2.2 for x86_64-unknown-linux):
	Simplifier ticks exhausted
  When trying RuleFired Class op return
  To increase the limit, use -fsimpl-tick-factor=N (default 100)
  If you need to do this, let GHC HQ know, and what factor you needed
  To see detailed counts use -ddump-simpl-stats
  Total ticks: 267047
  Call stack:
      CallStack (from HasCallStack):
        prettyCurrentCallStack, called at compiler/utils/Outputable.hs:1133:58 in ghc:Outputable
        callStackDoc, called at compiler/utils/Outputable.hs:1137:37 in ghc:Outputable
        pprPanic, called at compiler/simplCore/SimplMonad.hs:199:31 in ghc:SimplMonad

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

For GHC 8.0.2 and GHC 7.10.3, everything still worked fine. I used nix to do my testing with multiple compiler versions. I have this branch with the nix derivations I used that you may find useful and that you may or may not want to merge into the project: https://github.com/pa-ba/compdata/compare/master...srdqty:srd-nix?expand=1