### PR TITLE
Use `MonadFail` constraint when we need to `fail`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ env:
  - CABALVER=1.24 GHCVER=8.0.2  HAPPYVER=1.19.5
  - CABALVER=1.24 GHCVER=8.2.2  HAPPYVER=1.19.5
  - CABALVER=1.24 GHCVER=8.4.3  HAPPYVER=1.19.5
- - CABALVER=2.4 GHCVER=8.6.1  HAPPYVER=1.19.5
+ - CABALVER=2.4  GHCVER=8.6.1  HAPPYVER=1.19.5
+ - CABALVER=2.4  GHCVER=8.8.1  HAPPYVER=1.19.5
+ - CABALVER=2.4  GHCVER=8.10.2 HAPPYVER=1.19.5
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/benchmark/DataTypes.hs
+++ b/benchmark/DataTypes.hs
@@ -1,8 +1,11 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, CPP #-}
 
 module DataTypes where
 
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail
+#endif
 
 
 type Err = Either String

--- a/benchmark/Functions/Comp/Eval.hs
+++ b/benchmark/Functions/Comp/Eval.hs
@@ -7,7 +7,8 @@
   TypeOperators,
   ScopedTypeVariables,
   TypeSynonymInstances,
-  ConstraintKinds #-}
+  ConstraintKinds,
+  CPP #-}
 
 module Functions.Comp.Eval where
 
@@ -17,10 +18,12 @@ import Data.Comp
 import Data.Comp.Thunk hiding (eval, eval2)
 import Data.Comp.Derive
 
-import Control.Monad.Fail
-import Prelude hiding (fail)
-import Control.Monad hiding (fail)
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
+import Control.Monad
 
 -- evaluation with thunks
 

--- a/benchmark/Functions/Standard/Eval.hs
+++ b/benchmark/Functions/Standard/Eval.hs
@@ -1,22 +1,29 @@
+{-# LANGUAGE CPP                 #-}
+
 module Functions.Standard.Eval where
 
 import DataTypes.Standard
 import Functions.Standard.Desugar
 import Control.Monad
 
-coerceInt :: (Monad m) => SExpr -> m Int
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail (MonadFail)
+#endif
+
+coerceInt :: (MonadFail m) => SExpr -> m Int
 coerceInt (SInt i) = return i
 coerceInt _ = fail ""
 
-coerceBool :: (Monad m) => SExpr -> m Bool
+coerceBool :: (MonadFail m) => SExpr -> m Bool
 coerceBool (SBool b) = return b
 coerceBool _ = fail ""
 
-coercePair :: (Monad m) => SExpr -> m (SExpr,SExpr)
+coercePair :: (MonadFail m) => SExpr -> m (SExpr,SExpr)
 coercePair (SPair x y) = return (x,y)
 coercePair _ = fail ""
 
-eval :: (Monad m) => OExpr -> m SExpr
+eval :: (MonadFail m) => OExpr -> m SExpr
 eval (OInt i) = return $ SInt i
 eval (OBool b) = return $ SBool b
 eval (OPair x y) = liftM2 SPair (eval x) (eval y)

--- a/compdata.cabal
+++ b/compdata.cabal
@@ -190,7 +190,7 @@ library
 
 
 
-  Build-Depends:	base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1,
+  Build-Depends:	base >= 4.9, base < 5, template-haskell, containers, mtl >= 2.2.1,
                         QuickCheck >= 2, deepseq, transformers, th-expand-syns,
                         tree-view >= 0.5
   Extensions:           FlexibleContexts
@@ -202,7 +202,7 @@ Test-Suite test
   Type:                 exitcode-stdio-1.0
   Main-is:		Data_Test.hs
   hs-source-dirs:	testsuite/tests examples src
-  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1,
+  Build-Depends:        base >= 4.9, base < 5, template-haskell, containers, mtl >= 2.2.1,
                         QuickCheck >= 2, HUnit, test-framework, test-framework-hunit,
                         test-framework-quickcheck2 >= 0.3, deepseq, transformers, th-expand-syns
 
@@ -290,7 +290,7 @@ Benchmark algebra
   ghc-options:          -W -O2
   -- Disable short-cut fusion rules in order to compare optimised and unoptimised code.
   cpp-options:          -DNO_RULES
-  Build-Depends:        base >= 4.7, base < 5, template-haskell, containers, mtl >= 2.2.1,
+  Build-Depends:        base >= 4.9, base < 5, template-haskell, containers, mtl >= 2.2.1,
                         QuickCheck >= 2, deepseq, criterion, random, uniplate, transformers,
                         th-expand-syns
   Other-Modules:

--- a/examples/Examples/Thunk.hs
+++ b/examples/Examples/Thunk.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell, TypeOperators, MultiParamTypeClasses, DeriveFunctor,
-  FlexibleInstances, FlexibleContexts, UndecidableInstances, ConstraintKinds #-}
+  FlexibleInstances, FlexibleContexts, UndecidableInstances, ConstraintKinds,
+  CPP #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Examples.Thunk
@@ -22,7 +23,11 @@ import Data.Comp.Thunk
 import Data.Comp.Derive
 import Data.Comp.Show()
 import Examples.Common hiding (Value(..), Sig, iConst, iPair)
+
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail
+#endif
 
 -- Signature for values, strict pairs
 data Value a = Const Int | Pair !a !a deriving Functor


### PR DESCRIPTION
This PR fixes issue #29, and related issues that arose, but were not described by that issue.  This will also unblock issue #32, which is a result of the failing compilation on recent GHCs.

# Background

The acceptance of the [`MonadFail` proposal](https://wiki.haskell.org/MonadFail_Proposal) resulted in a breaking change in GHC 8.8.1 and onward, with an earlier migration period in older versions of `base`, in which `Monad`'s `fail` function is moved to a new class, `MonadFail`.  In earlier GHCs, `Monad` maintains its `fail` function for backwards compatibility, and `MonadFail` is defined in a separate module `Control.Monad.Fail`.  With GHC 8.8.1, the `fail` function is removed from `Monad`, and `MonadFail` is exported from `Prelude`.  What this means for us is that `compdata` and its benchmarks and examples fail to compile on these newer GHCs.

There have been two PRs to fix this issue already:

- PR #30, which was closed without being merged, and which took the approach of increasing the required version of `base`, which would limit us to only compiling on very recent GHCs, and
- PR #31, which breaks compilation on older GHCs silently.

Neither of these PRs fix the complete problem though, as they only change the `Data.Comp.Thunk` module, not the same issues that crop up in the benchmarks and the examples.

# This PR

The changes in this PR fix all the compilation errors and warnings related to the `MonadFail` proposal in 8.x-series GHCs by selectively importing the `Control.Monad.Fail` module, depending on the version of `base`, and adding `MonadFail` constraints where necessary.  To make sure our changes compile properly, we add newer GHCs to our travisci test matrix.

We also bump the required version of `base` to the one that started the `MonadFail` migration.  We think this is licensed, because we are already using `MonadFail` in parts of the code (which presumably caused [a failure in compilation on GHC 7.x](https://matrix.hackage.haskell.org/#/package/compdata)), and because commit fe05efb explicitly removes earlier GHCs from the test matrix.  If we want to support earlier versions of GHC, we can introduce a dependency on the [`fail` package](https://hackage.haskell.org/package/fail).

# Testing

This PR compiles without warnings on all tested 8.x-series GHCs: https://travis-ci.com/github/pniedzielski/compdata/builds/193484821