### PR TITLE
Bump dependencies, GHC 9.10.1

### DIFF
--- a/compdata.cabal
+++ b/compdata.cabal
@@ -1,5 +1,5 @@
 Name:			compdata
-Version:		0.13.1
+Version:		0.13.2
 Synopsis:            	Compositional Data Types
 Description:
 
@@ -187,11 +187,11 @@ library
 
 
 
-  Build-Depends:        base             >= 4.16   && < 4.20,
-                        QuickCheck       >= 2.14.3 && < 2.15,
+  Build-Depends:        base             >= 4.16   && < 4.22,
+                        QuickCheck       >= 2.14.3 && < 2.16,
                         containers       >= 0.6.5  && < 0.8,
-                        deepseq          >= 1.4    && < 1.6,
-                        template-haskell >= 2.17   && < 2.22,
+                        deepseq          >= 1.4    && < 1.7,
+                        template-haskell >= 2.17   && < 2.24,
                         mtl              >= 2.2.2  && < 2.4,
                         transformers     >= 0.5.6  && < 0.7,
                         th-expand-syns   >= 0.4.11 && < 0.5,

--- a/src/Data/Comp/Derive/Arbitrary.hs
+++ b/src/Data/Comp/Derive/Arbitrary.hs
@@ -41,7 +41,7 @@ class ArbitraryF f where
 makeArbitraryF :: Name -> Q [Dec]
 makeArbitraryF dt = do
   Just (DataInfo _cxt name args constrs _deriving) <- abstractNewtypeQ $ reify dt
-  let argNames = map (VarT . tyVarBndrName) (tail args)
+  let argNames = map (VarT . tyVarBndrName) (drop 1 args)
       complType = foldl AppT (ConT name) argNames
       preCond = map (mkClassP ''Arbitrary . (: [])) argNames
       classType = AppT (ConT ''ArbitraryF) complType
@@ -115,4 +115,4 @@ generateShrinkFDecl constrs
                  let ret = NoBindS $ AppE (VarE 'return) (foldl1 AppE ( ConE constr: map VarE resVarNs ))
                      stmtSeq = binds ++ [ret]
                      pat = ConP constr [] $ map VarP varNs
-                 return $ Clause [pat] (NormalB $ AppE (VarE 'tail) (DoE Nothing stmtSeq)) []
+                 return $ Clause [pat] (NormalB $ AppE (VarE 'tail') (DoE Nothing stmtSeq)) []

--- a/src/Data/Comp/Derive/Utils.hs
+++ b/src/Data/Comp/Derive/Utils.hs
@@ -21,6 +21,9 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.ExpandSyns
 
+tail' :: [a] -> [a]
+tail' = drop 1
+
 data DataInfo = forall flag . DataInfo Cxt Name [TyVarBndr flag] [Con] [DerivClause] 
 
 

--- a/src/Data/Comp/Matching.hs
+++ b/src/Data/Comp/Matching.hs
@@ -25,6 +25,7 @@ import Data.Comp.Equality
 import Data.Comp.Term
 import Data.Comp.Variables
 import Data.Foldable
+import Data.List (uncons)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Traversable
@@ -64,7 +65,7 @@ matchCxt c1 c2 = do
   res <- matchCxt' c1 c2
   let insts = Map.elems res
   mapM_ checkEq insts
-  return $ Map.map head res
+  traverse (fmap fst . uncons) res
     where checkEq [] = Nothing
           checkEq (c : cs)
               | all (== c) cs = Just ()


### PR DESCRIPTION
Also fixed a couple of warnings originating from `head`/`tail` usage.